### PR TITLE
Hide room names, show debug id's instead. Add min and max zoom on maps

### DIFF
--- a/modules/canvas/CampCanvas.tsx
+++ b/modules/canvas/CampCanvas.tsx
@@ -141,6 +141,8 @@ export const CampCanvas: FC<CampCanvasProps> = memo(({
     onDraw: handleDraw,
     onViewBoxChange: handleViewBoxChange,
     onViewChange: handleViewChange,
+    minScale: 0.01,
+    maxScale: 64,
   });
 
   /**

--- a/modules/side/SideGridView.tsx
+++ b/modules/side/SideGridView.tsx
@@ -8,11 +8,12 @@ import {getRoomPreviewUrl} from "../fetch/dataApi";
 
 export const SideGridView: FC<ChapterViewProps> = ({areaId, chapterId, sideId, checkpoint}) => (
   <Grid container spacing={1} pb={1} alignSelf="center">
-    {checkpoint.rooms.map(room => (
+    {checkpoint.rooms.map((room, i) => (
       <SideGridItem
         key={`${sideId}-${room.id}`}
         roomId={room.id}
-        {...room.name && {roomName: room.name}}
+        abbr={checkpoint.abbreviation}
+        roomNo={i + 1}
         image={getRoomPreviewUrl(areaId, chapterId, sideId, room.id)}
         href={`/${areaId}/${chapterId}/${sideId}/${room.id}`}
       />
@@ -20,7 +21,7 @@ export const SideGridView: FC<ChapterViewProps> = ({areaId, chapterId, sideId, c
   </Grid>
 );
 
-export const SideGridItem: FC<ChapterViewItemProps> = ({roomId, roomName, href, image}) => {
+export const SideGridItem: FC<ChapterViewItemProps & {abbr: string; roomNo: number}> = ({roomId, href, image, abbr, roomNo}) => {
   return (
     <Grid item xs={12} sm={6} md={4}>
       <Card>
@@ -36,15 +37,15 @@ export const SideGridItem: FC<ChapterViewItemProps> = ({roomId, roomName, href, 
                 unoptimized
                 layout="fill"
                 src={image}
-                alt={`Thumbnail for room ${roomName}`}
+                alt={`Thumbnail for room ${roomId}`}
                 style={{
                   imageRendering: "pixelated",
                 }}
               />
             </CardMedia>
             <ImageListItemBar
-              title={roomName}
-              subtitle={roomId}
+              title={roomId}
+              subtitle={`${abbr}-${roomNo}`}
               sx={{
                 fontSize: 26,
                 background: "linear-gradient(to right, rgba(0,0,0,0.5), rgba(0,0,0,0))",

--- a/modules/side/SideListView.tsx
+++ b/modules/side/SideListView.tsx
@@ -11,7 +11,7 @@ export const SideListView: FC<ChapterViewProps> = ({areaId, chapterId, sideId, c
       <SideListViewItem
         key={`${sideId}-${room.id}`}
         roomId={room.id}
-        {...room.name && {roomName: room.name}}
+        abbr={checkpoint.abbreviation}
         roomNo={roomIndex + 1}
         image={getRoomPreviewUrl(areaId, chapterId, sideId, room.id)}
         href={`/${areaId}/${chapterId}/${sideId}/${room.id}`}
@@ -20,7 +20,7 @@ export const SideListView: FC<ChapterViewProps> = ({areaId, chapterId, sideId, c
   </List>
 );
 
-const SideListViewItem: FC<ChapterViewItemProps & {roomNo: number}> = ({roomId, roomName, href, image, roomNo}) => (
+const SideListViewItem: FC<ChapterViewItemProps & {abbr: string; roomNo: number}> = ({roomId, roomName, href, image, roomNo, abbr}) => (
   <Link passHref href={href}>
     <ListItemButton
       disableGutters
@@ -34,9 +34,8 @@ const SideListViewItem: FC<ChapterViewItemProps & {roomNo: number}> = ({roomId, 
         width={80}
         height={45}
       />
-      <Typography component="div" marginLeft={2} color="text.secondary">{roomNo}.</Typography>
-      <Typography component="div" marginLeft={1} flexGrow={1}>{roomName}</Typography>
-      <Typography component="div" color="text.secondary" marginRight={0.5}>{roomId}</Typography>
+      <Typography component="div" marginLeft={2} flexGrow={1}>{roomId}</Typography>
+      <Typography component="div" color="text.secondary" marginRight={0.5}>{abbr}-{roomNo}</Typography>
     </ListItemButton>
   </Link>
 );

--- a/pages/[areaId]/[chapterId]/[sideId]/[roomId].tsx
+++ b/pages/[areaId]/[chapterId]/[sideId]/[roomId].tsx
@@ -15,7 +15,7 @@ import {VALID_AREAS} from "~/modules/data/validAreas";
 import {fetchArea, getRoomImageUrl, getRoomPreviewUrl} from "~/modules/fetch/dataApi";
 import {CampHead} from "~/modules/head/CampHead";
 import {useCampContext} from "~/modules/provide/CampContext";
-import {AreaData, ChapterData, CheckpointData, generateRoomTags, RoomData, SideData} from "~/modules/room";
+import {AreaData, ChapterData, CheckpointData, RoomData, SideData, generateRoomTags} from "~/modules/room";
 import {EntityList} from "~/modules/room/entityList/EntityList";
 import {teleport} from "~/modules/teleport/teleport";
 
@@ -101,7 +101,7 @@ const RoomPage: CampPage<RoomProps> = ({
   return (
     <Fragment>
       <CampHead
-        title={room.name ? `${room.name} (${room.debugId})` : room.debugId}
+        title={`${chapter.name} (${room.debugId})`}
         description={`${area.name} - ${chapter.name} - ${side.name} side - ${checkpoint.name}`}
         image={image}
       />
@@ -112,7 +112,7 @@ const RoomPage: CampPage<RoomProps> = ({
             {name: chapter.name, href: chapter.link},
             {name: side.name, href: sideLink},
             {name: checkpoint.name, href: `${sideLink}#${checkpoint.name}`},
-            {name: `${room.name} (${room.debugId})`},
+            {name: room.debugId},
           ]}
         />
         <HeaderNav
@@ -155,9 +155,10 @@ const RoomPage: CampPage<RoomProps> = ({
             {isFullscreen ? <FullscreenExit color="primary"/> : <Fullscreen color="primary"/>}
           </ToggleButton>
         </Paper>
-        <Typography component="div" variant="h5" mt={1}>{room.name}</Typography>
+        <Typography component="div" variant="h5" mt={1}>{room.debugId}</Typography>
         <Typography component="div" color="text.secondary">{chapter.name} › {side.name} Side › {checkpoint.name}</Typography>
-        <Typography component="div" color="text.secondary">Debug ID: {room.debugId}, Room ID: {room.roomId}, Room: {room.levelRoomNo}</Typography>
+        <Typography component="div" color="text.secondary">{room.roomId}</Typography>
+        <Typography component="div" color="text.secondary">{room.levelRoomNo}</Typography>
         <Stack direction="row" mt={1} mb={1.5} spacing={1}>
           {room.tags.map(tag => (
             <Link
@@ -287,8 +288,6 @@ export const getStaticProps: GetStaticProps<RoomProps, RoomParams> = async ({par
 
   const prevRoomId: string | undefined = checkpoint.roomOrder[roomIndex - 1] ?? side.checkpoints[room.checkpointNo - 1]?.roomOrder.slice(-1)[0];
   const nextRoomId: string | undefined = checkpoint.roomOrder[roomIndex + 1] ?? side.checkpoints[room.checkpointNo + 1]?.roomOrder[0];
-  const prevRoom: Room | undefined = prevRoomId ? side.rooms[prevRoomId] : undefined;
-  const nextRoom: Room | undefined = nextRoomId ? side.rooms[nextRoomId] : undefined;
 
   const sideRoomIndex = side.checkpoints.slice(0, room.checkpointNo).reduce<number>((prev, curr) => prev + curr.roomCount, 0) + roomIndex;
 
@@ -317,21 +316,21 @@ export const getStaticProps: GetStaticProps<RoomProps, RoomParams> = async ({par
         ...(room.name && {name: room.name}),
         debugId: roomId,
         roomId: `${checkpoint.abbreviation}-${roomIndex + 1}`,
-        levelRoomNo: `${sideRoomIndex + 1}/${side.roomCount}`,
-        checkpointRoomNo: `${roomIndex + 1}/${checkpoint.roomCount}`,
+        levelRoomNo: `${sideRoomIndex + 1} / ${side.roomCount}`,
+        checkpointRoomNo: `${roomIndex + 1} / ${checkpoint.roomCount}`,
         teleportParams: `?area=${area.gameId}/${chapter.gameId}&side=${sideId}&level=${roomId}${(room.entities.spawn && room.entities.spawn[0]?.x && room.entities.spawn[0]?.y) ? `&x=${room.entities.spawn[0].x}&y=${room.entities.spawn[0].y}` : ""}`,
         entities: room.entities,
         tags: generateRoomTags(room),
       },
-      ...(prevRoom && {
+      ...(prevRoomId && {
         prevRoom: {
-          label: prevRoom.name,
+          label: prevRoomId,
           link: `/${areaId}/${chapterId}/${sideId}/${prevRoomId}`,
         }
       }),
-      ...(nextRoom && {
+      ...(nextRoomId && {
         nextRoom: {
-          label: nextRoom.name,
+          label: nextRoomId,
           link: `/${areaId}/${chapterId}/${sideId}/${nextRoomId}`,
         }
       }),


### PR DESCRIPTION
Hide room names, they are old and silly and no one is using them. Can still be searched in case someone is looking for 'windsprings'. Also added min and max zoom to map.